### PR TITLE
OpenCV 4.0 couldn't be used from python 3.7 because a symbolic link was missing.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN wget https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip \
   .. \
 && make install \
 && rm /${OPENCV_VERSION}.zip \
-&& rm -r /opencv-${OPENCV_VERSION} \
-&& ln -s \
+&& rm -r /opencv-${OPENCV_VERSION} 
+RUN ln -s \
   /usr/local/python/cv2/python-3.7/cv2.cpython-37m-x86_64-linux-gnu.so \
   /usr/local/lib/python3.7/site-packages/cv2.so


### PR DESCRIPTION
I built the Dockerfile and tried to execute  `python -c "import cv2; print(cv2.__version__)"` .
Though I got error.

Finally, I found a symbolic link was missing, and Added it.

Actually, I do not know if hard cording `cv2.cpython-37m-x86_64-linux-gnu.so` is allowed, though this modification fixed my issue.
Thank you.