### PR TITLE
1) Solve #22 on opencv_contrib branch 2) Add OPENCV_ENABLE_NONFREE=ON

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN wget https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip \
   -DWITH_V4L=ON \
   -DBUILD_TESTS=OFF \
   -DBUILD_PERF_TESTS=OFF \
+  -DOPENCV_ENABLE_NONFREE=ON \
   -DCMAKE_BUILD_TYPE=RELEASE \
   -DCMAKE_INSTALL_PREFIX=$(python3.7 -c "import sys; print(sys.prefix)") \
   -DPYTHON_EXECUTABLE=$(which python3.7) \
@@ -51,3 +52,6 @@ RUN wget https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip \
 && make install \
 && rm /${OPENCV_VERSION}.zip \
 && rm -r /opencv-${OPENCV_VERSION}
+RUN ln -s \
+  /usr/local/python/cv2/python-3.7/cv2.cpython-37m-x86_64-linux-gnu.so \
+  /usr/local/lib/python3.7/site-packages/cv2.so


### PR DESCRIPTION
1) Solve [Issue#22](https://github.com/janza/docker-python3-opencv/issues/22) on opencv_contrib branch. It is based on [PR#21](https://github.com/janza/docker-python3-opencv/pull/21).
2) Add `OPENCV_ENABLE_NONFREE=ON` flag on cmake. It enables for user to use some patented algorithm such as SIFT.

I tested `import cv2; cv2.xfeatures2d.SIFT_create` and it looked fine.